### PR TITLE
Specify tested versions of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.6..3.29)
 
 if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6..3.29)
+cmake_minimum_required (VERSION 2.6..3.19)
 
 if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6..3.19)
+cmake_minimum_required (VERSION 2.6...3.19)
 
 if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")


### PR DESCRIPTION
Newer version of CMake have begun droping support for older CMake builds that don't
explicitly call out support for versions >= 3.5.
You can see a list of these changes here https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version
This lead to an error during installation of libusb on Arch Linux which is using 
CMake 4.0.0 at the time of writing.

I tested libnfc with CMake 3.19 and it worked fine though things do
break at 3.20.
